### PR TITLE
Add features import

### DIFF
--- a/pcg_skel/__init__.py
+++ b/pcg_skel/__init__.py
@@ -1,5 +1,6 @@
 from .pcg_anno import *
 from .pcg_skel import *
+from .features import *
 from . import utils
 from . import chunk_tools
 


### PR DESCRIPTION
This adds the `features.py` file to the main module imports

If this was not the intention, could we somehow indicate how these functions should be imported in the docs? right now they are listed at the same level so it was confusing to me that the namespaces were different from the other two submodules